### PR TITLE
Corrected publication.title not showing on light mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The recommended approach is deploying to Vercel. If you don't have an account al
 - Create a new project on Vercel and connect this repo
 - It's a monorepo. So, choose either `packages/blog-starter-kit/themes/enterprise` or `packages/blog-starter-kit/themes/personal` as the root directory while importing on Vercel.
 
-  ![selecting the directory to deploy a monorepo](https://github.com/victornwakpa/starter-kit/assets/61851642/f6d25a80-065a-48a2-9501-4047de544eb5)
+  ![selecting the directory to deploy a monorepo](https://cdn.hashnode.com/res/hashnode/image/upload/v1698839884060/O8OoBML5v.PNG?auto=format)
 
 - Choose `Next.js` as framework preset (just above Root Directory setting).
 - Set the following environment variables

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ The recommended approach is deploying to Vercel. If you don't have an account al
 - Fork this repo
 - Create a new project on Vercel and connect this repo
 - It's a monorepo. So, choose either `packages/blog-starter-kit/themes/enterprise` or `packages/blog-starter-kit/themes/personal` as the root directory while importing on Vercel.
-  ![selecting the directory to deploy a monorepo](https://cdn.hashnode.com/res/hashnode/image/upload/v1695083263935/T5bByLxZT.png?w=500&h=800&auto=format)
+
+  ![selecting the directory to deploy a monorepo](https://github.com/victornwakpa/starter-kit/assets/61851642/f6d25a80-065a-48a2-9501-4047de544eb5)
+
 - Choose `Next.js` as framework preset (just above Root Directory setting).
 - Set the following environment variables
 

--- a/packages/blog-starter-kit/themes/enterprise/components/footer.tsx
+++ b/packages/blog-starter-kit/themes/enterprise/components/footer.tsx
@@ -20,7 +20,7 @@ export const Footer = () => {
 						</Link>
 					</div>
 				) : (
-					<p className="mb-20 text-center text-xl font-semibold text-black dark:text-white md:text-4xl">
+					<p className="mb-20 text-center text-xl font-semibold text-slate-900 dark:text-white md:text-4xl">
 						{publication.title}
 					</p>
 				)}

--- a/packages/blog-starter-kit/themes/enterprise/components/footer.tsx
+++ b/packages/blog-starter-kit/themes/enterprise/components/footer.tsx
@@ -20,7 +20,7 @@ export const Footer = () => {
 						</Link>
 					</div>
 				) : (
-					<p className="mb-20 text-center text-xl font-semibold text-white md:text-4xl">
+					<p className="mb-20 text-center text-xl font-semibold text-black dark:text-white md:text-4xl">
 						{publication.title}
 					</p>
 				)}

--- a/packages/blog-starter-kit/themes/enterprise/components/footer.tsx
+++ b/packages/blog-starter-kit/themes/enterprise/components/footer.tsx
@@ -20,7 +20,7 @@ export const Footer = () => {
 						</Link>
 					</div>
 				) : (
-					<p className="mb-20 text-center text-xl font-semibold text-slate-900 dark:text-white md:text-4xl">
+					<p className="mb-20 text-center text-xl font-semibold text-slate-900 dark:text-slate-50 md:text-4xl">
 						{publication.title}
 					</p>
 				)}


### PR DESCRIPTION
When using the light mode, the "publication.title" does not show because there is no light mode color assigned to it.

Fixed that by giving the default color: text-slate-900, then on dark mode: text-white

![image](https://github.com/Hashnode/starter-kit/assets/61851642/7a0553fd-46d8-4313-af37-aa9800f7f2fd)
