### PR TITLE
feat: increase page max width to '768px'

### DIFF
--- a/packages/blog-starter-kit/themes/personal/pages/[slug].tsx
+++ b/packages/blog-starter-kit/themes/personal/pages/[slug].tsx
@@ -138,7 +138,7 @@ export default function PostOrPage({ publication, post, page }: Props) {
 	return (
 		<AppProvider publication={publication} post={post}>
 			<Layout>
-				<Container className="mx-auto flex max-w-2xl flex-col items-stretch gap-10 px-5 py-10">
+				<Container className="mx-auto flex max-w-3xl flex-col items-stretch gap-10 px-5 py-10">
 					<PersonalHeader />
 					<article className="flex flex-col items-start gap-10 pb-10">
 						{post ? Post(publication, post) : Page(page)}

--- a/packages/blog-starter-kit/themes/personal/pages/index.tsx
+++ b/packages/blog-starter-kit/themes/personal/pages/index.tsx
@@ -83,7 +83,7 @@ export default function Index({ publication, initialPosts, initialPageInfo }: Pr
 						}}
 					/>
 				</Head>
-				<Container className="mx-auto flex max-w-2xl flex-col items-stretch gap-10 px-5 py-10">
+				<Container className="mx-auto flex max-w-3xl flex-col items-stretch gap-10 px-5 py-10">
 					<PersonalHeader />
 					{posts.length > 0 && <MinimalPosts context="home" posts={posts} />}
 					{!loadedMore && pageInfo.hasNextPage && pageInfo.endCursor && (

--- a/packages/blog-starter-kit/themes/personal/pages/preview/[id].tsx
+++ b/packages/blog-starter-kit/themes/personal/pages/preview/[id].tsx
@@ -55,7 +55,7 @@ export default function Post({ publication, post }: Props) {
 	return (
 		<AppProvider publication={publication} post={post}>
 			<Layout>
-				<Container className="mx-auto flex max-w-2xl flex-col items-stretch gap-10 px-5 py-10">
+				<Container className="mx-auto flex max-w-3xl flex-col items-stretch gap-10 px-5 py-10">
 					<PersonalHeader />
 					<article className="flex flex-col items-start gap-10 pb-10">
 						<Head>

--- a/packages/blog-starter-kit/themes/personal/pages/tag/[slug].tsx
+++ b/packages/blog-starter-kit/themes/personal/pages/tag/[slug].tsx
@@ -44,7 +44,7 @@ export default function Tag({ publication, posts, tag }: Props) {
 						dangerouslySetInnerHTML={{ __html: JSON.stringify(addPublicationJsonLd(publication)) }}
 					/>
 				</Head>
-				<Container className="mx-auto flex max-w-2xl flex-col items-stretch gap-10 px-5 py-10">
+				<Container className="mx-auto flex max-w-3xl flex-col items-stretch gap-10 px-5 py-10">
 					<PersonalHeader />
 					<div className="flex flex-col gap-1 pt-5">
 						<p className="font-bold uppercase text-slate-500 dark:text-neutral-400">Tag</p>


### PR DESCRIPTION
This PR increases the max width of the blog page to '768px' from '672px'. This adjustment creates a more spacious environment, allowing content to breathe. The old '672px' width made it hard for me and others to read comfortably.