### PR TITLE
Change revalidation interval for publication home page info to 1 sec

### DIFF
--- a/packages/blog-starter-kit/themes/hashnode/pages/index.tsx
+++ b/packages/blog-starter-kit/themes/hashnode/pages/index.tsx
@@ -265,7 +265,6 @@ export const getStaticProps = async () => {
 		};
 	}
 
-	const hasPostViewsActive = !!publicationInfo.data?.publication.features.viewCount.isEnabled;
 	return {
 		props: {
 			publication,
@@ -274,8 +273,6 @@ export const getStaticProps = async () => {
 			host,
 			isHome: true,
 		},
-		revalidate: hasPostViewsActive
-			? REVALIDATION_INTERVAL_POST_VIEWS_ACTIVE
-			: REVALIDATION_INTERVAL,
+		revalidate: 1,
 	};
 };


### PR DESCRIPTION
New posts are not getting reflected in UI after creation. So the revalidation logic for posts present in publication home page is being changed.