### PR TITLE
docs: remove vercel deploy buttons

### DIFF
--- a/packages/blog-starter-kit/themes/enterprise/README.md
+++ b/packages/blog-starter-kit/themes/enterprise/README.md
@@ -1,15 +1,11 @@
 # A statically generated blog example using Next.js, Markdown, and TypeScript with Hashnode 💫
 
-This is the existing [blog-starter](https://github.com/vercel/next.js/tree/canary/examples/blog-starter) plus TypeScript.
-wired with [Hashnode](https://hashnode.com).
+This is the existing [blog-starter](https://github.com/vercel/next.js/tree/canary/examples/blog-starter) plus TypeScript, wired with [Hashnode](https://hashnode.com).
 
-We've used [Hashnode API's](https://apidocs.hashnode.com) and integrated them with this blog starter kit.
+We've used [Hashnode APIs](https://apidocs.hashnode.com) and integrated them with this blog starter kit.
 
 ## Want to have your own?
 
-Fork it and change the environment variable `NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST` to your host (engineering.hashnode.dev is the host in the example) and deploy it to Vercel.
-That's it! You now have your own frontend. You can still use Hashnode for writing your Articles.
+Fork it and change the environment variable `NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST` to your host (engineering.hashnode.dev is the host in the example) and deploy it to Vercel. That's it! You now have your own frontend. You can still use Hashnode for writing your Articles.
 
-## Demo
-
-[https://demo.hashnode.com/engineering](https://demo.hashnode.com/engineering)
+Demo of this theme: [https://demo.hashnode.com/engineering](https://demo.hashnode.com/engineering).

--- a/packages/blog-starter-kit/themes/enterprise/README.md
+++ b/packages/blog-starter-kit/themes/enterprise/README.md
@@ -8,4 +8,4 @@ We've used [Hashnode APIs](https://apidocs.hashnode.com) and integrated them wit
 
 Fork it and change the environment variable `NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST` to your host (engineering.hashnode.dev is the host in the example) and deploy it to Vercel. That's it! You now have your own frontend. You can still use Hashnode for writing your Articles.
 
-Demo of this theme: [https://demo.hashnode.com/engineering](https://demo.hashnode.com/engineering).
+Demo of the `enterprise` theme: [https://demo.hashnode.com/engineering](https://demo.hashnode.com/engineering).

--- a/packages/blog-starter-kit/themes/enterprise/README.md
+++ b/packages/blog-starter-kit/themes/enterprise/README.md
@@ -12,20 +12,4 @@ That's it! You now have your own frontend. You can still use Hashnode for writin
 
 ## Demo
 
-[https://next-blog-starter.vercel.app/](https://next-blog-starter.vercel.app/)
-
-## Deploy your own
-
-Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example) or preview live with [StackBlitz](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/blog-starter)
-
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/next.js/tree/canary/examples/blog-starter&project-name=blog-starter&repository-name=blog-starter)
-
-# Notes
-
-`blog-starter` uses [Tailwind CSS](https://tailwindcss.com) [(v3.0)](https://tailwindcss.com/blog/tailwindcss-v3).
-
-## To-Do
-
-- [ ] Pagination
-- [ ] Vercel Deploy Button
-- [ ] Submit as Template
+[https://demo.hashnode.com/engineering](https://demo.hashnode.com/engineering)

--- a/packages/blog-starter-kit/themes/hashnode/README.md
+++ b/packages/blog-starter-kit/themes/hashnode/README.md
@@ -1,31 +1,11 @@
 # A statically generated blog example using Next.js, Markdown, and TypeScript with Hashnode 💫
 
-This is the existing [blog-starter](https://github.com/vercel/next.js/tree/canary/examples/blog-starter) plus TypeScript.
-wired with [Hashnode](https://hashnode.com).
+This is the existing [blog-starter](https://github.com/vercel/next.js/tree/canary/examples/blog-starter) plus TypeScript, wired with [Hashnode](https://hashnode.com).
 
-We've used [Hashnode API's](https://apidocs.hashnode.com) and integrated them with this blog starter kit.
+We've used [Hashnode APIs](https://apidocs.hashnode.com) and integrated them with this blog starter kit.
 
 ## Want to have your own?
 
-Fork it and change the environment variable `NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST` to your host (engineering.hashnode.dev is the host in the example) and deploy it to Vercel.
-That's it! You now have your own frontend. You can still use Hashnode for writing your Articles.
+Fork it and change the environment variable `NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST` to your host (engineering.hashnode.dev is the host in the example) and deploy it to Vercel. That's it! You now have your own frontend. You can still use Hashnode for writing your Articles.
 
-## Demo
-
-[https://next-blog-starter.vercel.app/](https://next-blog-starter.vercel.app/)
-
-## Deploy your own
-
-Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example) or preview live with [StackBlitz](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/blog-starter)
-
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/next.js/tree/canary/examples/blog-starter&project-name=blog-starter&repository-name=blog-starter)
-
-# Notes
-
-`blog-starter` uses [Tailwind CSS](https://tailwindcss.com) [(v3.0)](https://tailwindcss.com/blog/tailwindcss-v3).
-
-## To-Do
-
-- [ ] Pagination
-- [ ] Vercel Deploy Button
-- [ ] Submit as Template
+Demo of this theme: [https://saikrishna.dev/blog](https://saikrishna.dev/blog).

--- a/packages/blog-starter-kit/themes/hashnode/README.md
+++ b/packages/blog-starter-kit/themes/hashnode/README.md
@@ -8,4 +8,4 @@ We've used [Hashnode APIs](https://apidocs.hashnode.com) and integrated them wit
 
 Fork it and change the environment variable `NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST` to your host (engineering.hashnode.dev is the host in the example) and deploy it to Vercel. That's it! You now have your own frontend. You can still use Hashnode for writing your Articles.
 
-Demo of this theme: [https://saikrishna.dev/blog](https://saikrishna.dev/blog).
+Demo of the `hashnode` theme: [https://saikrishna.dev/blog](https://saikrishna.dev/blog).

--- a/packages/blog-starter-kit/themes/personal/README.md
+++ b/packages/blog-starter-kit/themes/personal/README.md
@@ -1,31 +1,11 @@
 # A statically generated blog example using Next.js, Markdown, and TypeScript with Hashnode 💫
 
-This is the existing [blog-starter](https://github.com/vercel/next.js/tree/canary/examples/blog-starter) plus TypeScript.
-wired with [Hashnode](https://hashnode.com).
+This is the existing [blog-starter](https://github.com/vercel/next.js/tree/canary/examples/blog-starter) plus TypeScript, wired with [Hashnode](https://hashnode.com).
 
-We've used [Hashnode API's](https://apidocs.hashnode.com) and integrated them with this blog starter kit.
+We've used [Hashnode APIs](https://apidocs.hashnode.com) and integrated them with this blog starter kit.
 
 ## Want to have your own?
 
-Fork it and change the environment variable `NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST` to your host (engineering.hashnode.dev is the host in the example) and deploy it to Vercel.
-That's it! You now have your own frontend. You can still use Hashnode for writing your Articles.
+Fork it and change the environment variable `NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST` to your host (engineering.hashnode.dev is the host in the example) and deploy it to Vercel. That's it! You now have your own frontend. You can still use Hashnode for writing your Articles.
 
-## Demo
-
-[https://next-blog-starter.vercel.app/](https://next-blog-starter.vercel.app/)
-
-## Deploy your own
-
-Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example) or preview live with [StackBlitz](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/blog-starter)
-
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/vercel/next.js/tree/canary/examples/blog-starter&project-name=blog-starter&repository-name=blog-starter)
-
-# Notes
-
-`blog-starter` uses [Tailwind CSS](https://tailwindcss.com) [(v3.0)](https://tailwindcss.com/blog/tailwindcss-v3).
-
-## To-Do
-
-- [ ] Pagination
-- [ ] Vercel Deploy Button
-- [ ] Submit as Template
+Demo of this theme: [https://sandeep.dev/blog](https://sandeep.dev/blog).

--- a/packages/blog-starter-kit/themes/personal/README.md
+++ b/packages/blog-starter-kit/themes/personal/README.md
@@ -8,4 +8,4 @@ We've used [Hashnode APIs](https://apidocs.hashnode.com) and integrated them wit
 
 Fork it and change the environment variable `NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST` to your host (engineering.hashnode.dev is the host in the example) and deploy it to Vercel. That's it! You now have your own frontend. You can still use Hashnode for writing your Articles.
 
-Demo of this theme: [https://sandeep.dev/blog](https://sandeep.dev/blog).
+Demo of the `personal` theme: [https://sandeep.dev/blog](https://sandeep.dev/blog).


### PR DESCRIPTION
The deploy buttons in each theme under the "Deploy your own" section of the README are quite misleading. I spent quite some time using it to deploy the theme, thinking it was going to deploy the actual theme, but as expected, it was deploying the original [blog-starter](https://github.com/vercel/next.js/tree/canary/examples/blog-starter) instead.

<img width="1133" alt="Screenshot 2024-01-30 at 16 58 36" src="https://github.com/Hashnode/starter-kit/assets/30334776/eaf3ef45-db5b-4988-98a0-c26fc9ba014b">

Given that users are expected to fork this repository before deployment and the [base README](https://github.com/Hashnode/starter-kit/blob/main/README.md#how-to-deploy) already does justice to the deployment process, I'm suggesting removing the deploy buttons to avoid confusion. Please feel free to change the copy if you want, I only removed the necessary sections and linked to the demos for each of the theme.

Do let me know what you think; thanks.
