### PR TITLE
feat: add read time and reaction count to slug page

### DIFF
--- a/packages/blog-starter-kit/themes/personal/pages/[slug].tsx
+++ b/packages/blog-starter-kit/themes/personal/pages/[slug].tsx
@@ -128,11 +128,15 @@ const Post = ({ publication, post }: PostProps) => {
 				/>
 				<style dangerouslySetInnerHTML={{ __html: highlightJsMonokaiTheme }}></style>
 			</Head>
-			<h1 className="text-4xl leading-tight tracking-tight text-black dark:text-white">
+			<h1 className="text-4xl font-bold leading-tight tracking-tight text-black dark:text-white">
 				{post.title}
 			</h1>
-			<div className="text-neutral-600 dark:text-neutral-400">
+			<div className="flex tracking-tight gap-2 text-neutral-600 dark:text-neutral-400">
 				<DateFormatter dateString={post.publishedAt} />
+				{'•'}
+				<span>{post.readTimeInMinutes} min read</span>
+				{'•'}
+        <span>{post.reactionCount} likes</span>
 			</div>
 			{!!coverImageSrc && (
 				<div className="w-full">

--- a/packages/blog-starter-kit/themes/personal/pages/[slug].tsx
+++ b/packages/blog-starter-kit/themes/personal/pages/[slug].tsx
@@ -135,8 +135,6 @@ const Post = ({ publication, post }: PostProps) => {
 				<DateFormatter dateString={post.publishedAt} />
 				{'•'}
 				<span>{post.readTimeInMinutes} min read</span>
-				{'•'}
-        <span>{post.reactionCount} likes</span>
 			</div>
 			{!!coverImageSrc && (
 				<div className="w-full">


### PR DESCRIPTION
Included read time and reaction count display on the page of a blog post.