### PR TITLE
Fixes Dockerfile issue with .env.example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN npm install -g pnpm
 ARG THEME=enterprise
 
 WORKDIR /app/packages/blog-starter-kit/themes/${THEME}
-
+RUN cp .env.example .env.local
 RUN pnpm install --frozen-lockfile
 
 RUN pnpm build


### PR DESCRIPTION
Fixes  #77 in the dockerfile

```
STEP 8/10: RUN pnpm build

> @starter-kit/blog-enterprise@ build /app/packages/blog-starter-kit/themes/enterprise
> next build


> Build error occurred
TypeError: Cannot read properties of undefined (reading 'document')
    at parseRequestExtendedArgs (/app/node_modules/.pnpm/graphql-request@6.1.0_graphql@16.8.1/node_modules/graphql-request/build/cjs/parseArgs.js:38:25)
    at request (/app/node_modules/.pnpm/graphql-request@6.1.0_graphql@16.8.1/node_modules/graphql-request/build/cjs/index.js:330:72)
    at getRedirectionRules (/app/packages/blog-starter-kit/themes/enterprise/next.config.js:31:21)
    at Object.redirects (/app/packages/blog-starter-kit/themes/enterprise/next.config.js:88:16)
    at loadRedirects (/app/node_modules/.pnpm/next@13.5.5_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/lib/load-custom-routes.js:360:34)
    at loadCustomRoutes (/app/node_modules/.pnpm/next@13.5.5_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/lib/load-custom-routes.js:438:9)
    at /app/node_modules/.pnpm/next@13.5.5_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/build/index.js:215:134
    at Span.traceAsyncFn (/app/node_modules/.pnpm/next@13.5.5_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/trace/trace.js:105:26)
    at /app/node_modules/.pnpm/next@13.5.5_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/build/index.js:215:87
    at async Span.traceAsyncFn (/app/node_modules/.pnpm/next@13.5.5_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/trace/trace.js:105:20)
 ELIFECYCLE  Command failed with exit code 1.
Error: building at STEP "RUN pnpm build": while running runtime: exit status 1
```