### PR TITLE
Hide table of contents if no table items are available

### DIFF
--- a/packages/blog-starter-kit/themes/enterprise/components/post-header.tsx
+++ b/packages/blog-starter-kit/themes/enterprise/components/post-header.tsx
@@ -88,7 +88,7 @@ export const PostHeader = ({ title, coverImage, date, author, readTimeInMinutes 
 				<div className="mb-5 flex w-full flex-row items-center justify-center md:mb-0 md:w-auto md:justify-start">
 					<span className="mx-3 hidden font-bold text-slate-500 md:block">&middot;</span>
 					<DateFormatter dateString={date} />
-					{readTimeInMinutes && <span className="mx-3 hidden font-bold text-slate-500 md:block">&middot;</span>}
+					{readTimeInMinutes && <span className="mx-3 font-bold text-slate-500">&middot;</span>}
 					<ReadTimeInMinutes readTimeInMinutes={readTimeInMinutes} />
 				</div>
 			</div>

--- a/packages/blog-starter-kit/themes/enterprise/pages/[slug].tsx
+++ b/packages/blog-starter-kit/themes/enterprise/pages/[slug].tsx
@@ -133,7 +133,7 @@ const Post = ({ publication, post }: PostProps) => {
 				author={post.author}
 				readTimeInMinutes={post.readTimeInMinutes}
 			/>
-			{post.features.tableOfContents.isEnabled && post.features.tableOfContents.items.length > 0 && <PostTOC />}
+			{post.features.tableOfContents.isEnabled && post.features?.tableOfContents?.items?.length > 0 && <PostTOC />}
 			<MarkdownToHtml contentMarkdown={post.content.markdown} />
 			{(post.tags ?? []).length > 0 && (
 				<div className="mx-auto w-full px-5 text-slate-600 dark:text-neutral-300 md:max-w-screen-md">

--- a/packages/blog-starter-kit/themes/enterprise/pages/[slug].tsx
+++ b/packages/blog-starter-kit/themes/enterprise/pages/[slug].tsx
@@ -133,7 +133,7 @@ const Post = ({ publication, post }: PostProps) => {
 				author={post.author}
 				readTimeInMinutes={post.readTimeInMinutes}
 			/>
-			{post.features.tableOfContents.isEnabled && <PostTOC />}
+			{post.features.tableOfContents.isEnabled && post.features.tableOfContents.items.length > 0 && <PostTOC />}
 			<MarkdownToHtml contentMarkdown={post.content.markdown} />
 			{(post.tags ?? []).length > 0 && (
 				<div className="mx-auto w-full px-5 text-slate-600 dark:text-neutral-300 md:max-w-screen-md">

--- a/packages/blog-starter-kit/themes/hashnode/components/post-header.tsx
+++ b/packages/blog-starter-kit/themes/hashnode/components/post-header.tsx
@@ -264,7 +264,7 @@ export const PostHeader = ({ post, morePosts }: Props) => {
 			<div className="blog-content-wrapper article-main-wrapper container relative z-30 mx-auto grid grid-flow-row grid-cols-8 xl:gap-6 2xl:grid-cols-10">
 				<section className="blog-content-main z-20 col-span-8 mb-10 px-4 md:z-10 lg:col-span-6 lg:col-start-2 lg:px-0 xl:col-span-6 xl:col-start-2 2xl:col-span-6 2xl:col-start-3">
 					<div className="relative">
-						{post.features?.tableOfContents?.isEnabled && <TocRenderDesign list={toc} />}
+						{post.features?.tableOfContents?.isEnabled && post.features?.tableOfContents?.items?.length > 0 && <TocRenderDesign list={toc} />}
 
 						{/* {isPublicationPost && renderPinnedWidgets(props.widgets, 'top')} */}
 


### PR DESCRIPTION
This PR fixes two issues:

- Gap between Date and read time on Mobile devices
![image](https://github.com/user-attachments/assets/5f201d38-ae03-475f-862d-5734aee75e55)

- Table of contents rendered empty in enterprise and hashnode theme
![image](https://github.com/user-attachments/assets/62b40588-e65f-4299-aaa9-ac6d96d81bac)
