### PR TITLE
Fixes nextjs image rendering

### DIFF
--- a/packages/blog-starter-kit/themes/enterprise/next.config.js
+++ b/packages/blog-starter-kit/themes/enterprise/next.config.js
@@ -65,6 +65,7 @@ const config = {
 		scrollRestoration: true,
 	},
 	images: {
+		unoptimized: true,
 		remotePatterns: [
 			{
 				protocol: 'https',

--- a/packages/blog-starter-kit/themes/hashnode/next.config.js
+++ b/packages/blog-starter-kit/themes/hashnode/next.config.js
@@ -65,6 +65,7 @@ const config = {
 		scrollRestoration: true,
 	},
 	images: {
+		unoptimized: true,
 		remotePatterns: [
 			{
 				protocol: 'https',

--- a/packages/blog-starter-kit/themes/personal/next.config.js
+++ b/packages/blog-starter-kit/themes/personal/next.config.js
@@ -65,6 +65,7 @@ const config = {
 		scrollRestoration: true,
 	},
 	images: {
+		unoptimized: true,
 		remotePatterns: [
 			{
 				protocol: 'https',


### PR DESCRIPTION
Issue:
In the current setup, images from `cdn.hashnode.com` are being proxied through Next.js’s image optimization (i.e., _next/image route). This results in images loading through the application server, rather than directly from the CDN, which is unnecessary since the CDN already serves optimized images. This setup also introduces additional processing overhead on the application.

Change:
Updated next.config.js to set the unoptimized flag in the images configuration to true. This change ensures all images are served directly from their source (e.g., cdn.hashnode.com) without additional optimization through Next.js.