### PR TITLE
Fix/bot crawling indexing

### DIFF
--- a/packages/blog-starter-kit/themes/personal/next.config.js
+++ b/packages/blog-starter-kit/themes/personal/next.config.js
@@ -83,6 +83,10 @@ const config = {
 				source: '/api/analytics',
 				destination: `${HASHNODE_ADVANCED_ANALYTICS_URL}/api/analytics`,
 			},
+			{
+				source: '/feed.xml',
+				destination: '/rss.xml',
+			},
 		];
 	},
 	async redirects() {

--- a/packages/blog-starter-kit/themes/personal/pages/favicon.ico.tsx
+++ b/packages/blog-starter-kit/themes/personal/pages/favicon.ico.tsx
@@ -1,0 +1,39 @@
+import request from 'graphql-request';
+import { type GetServerSideProps } from 'next';
+import {
+	PublicationByHostDocument,
+	PublicationByHostQuery,
+	PublicationByHostQueryVariables,
+} from '../generated/graphql';
+
+const GQL_ENDPOINT = process.env.NEXT_PUBLIC_HASHNODE_GQL_ENDPOINT;
+const FaviconIco = () => null;
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+	const { res } = ctx;
+	const host = process.env.NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST;
+	if (!host) {
+		throw new Error('Could not determine host');
+	}
+
+	const data = await request<PublicationByHostQuery, PublicationByHostQueryVariables>(
+		GQL_ENDPOINT,
+		PublicationByHostDocument,
+		{
+			host: process.env.NEXT_PUBLIC_HASHNODE_PUBLICATION_HOST,
+		},
+	);
+	if (!data.publication?.favicon) throw new Error('Favicon could not be found');
+
+	const faviconResponse = await fetch(data.publication.favicon);
+	const faviconBuffer = await faviconResponse.arrayBuffer();
+
+	res.setHeader('Cache-Control', 's-maxage=86400, stale-while-revalidate');
+	res.setHeader('content-type', 'image/x-icon');
+	res.write(Buffer.from(faviconBuffer));
+	res.end();
+
+	return { props: {} };
+};
+
+export default FaviconIco;


### PR DESCRIPTION
This PR addresses several fixes related to bot crawling and indexing of deployed blogs:
   - Added a `try-catch` block to capture request errors when fetching unknown slugs like `feed` for example.
   - Added a route handler for serving favicon. This complies with SEO best practices.
   - Added a redirect rule in the `next.config.js` file to redirect requests from `/feed.xml` to `/rss.xml`.
### Summary
I noticed that my blog wasn't being indexed at all, so I used Google Search Console to debug the issues. The report highlighted the problems addressed in this PR.