### PR TITLE
enterprise theme - index.tsx - line 131

### DIFF
--- a/packages/blog-starter-kit/themes/enterprise/pages/index.tsx
+++ b/packages/blog-starter-kit/themes/enterprise/pages/index.tsx
@@ -128,7 +128,7 @@ export default function Index({ publication, initialAllPosts, initialPageInfo }:
 						<div className="grid grid-cols-1 py-20 lg:grid-cols-3">
 							<div className="col-span-1 flex flex-col items-center gap-5 text-center text-slate-700 dark:text-neutral-400 lg:col-start-2">
 								<div className="w-20">
-									<ArticleSVG clasName="stroke-current" />
+									<ArticleSVG className="stroke-current" />
 								</div>
 								<p className="text-xl font-semibold ">
 									Hang tight! We&apos;re drafting the first article.


### PR DESCRIPTION
This pull request includes a small fix to the `Index` page of the blog starter kit. The change corrects a typo ("clasName") in the `ArticleSVG` component's props, ensuring the correct attribute is used for styling.